### PR TITLE
now no need to explicitly pass {} via js api

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ function plugin(opts) {
       src     = path.join(root, metalsmith._source),
       install = path.join(root, 'components');
 
-    if (opts === {}) {
+    if (!opts) {
 
       async.map(Object.keys(files), function (file, cb) {
         var duo = new Duo(src)

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/axyz/metalsmith-duo"
+  },
   "author": "Andrea Moretti (@axyz)",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
before, checking `opts === {}` meant that, via the JS api, you had to explicitly pass `{}`:

```
var metalsmith = new Metalsmith(dir)
  .use(duo({})
  .build();
```

now, you can just omit the parameter.

also added the repo in the `package.json` so people can click to it via NPM.