### PR TITLE
use latest version of duo

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "async": "^0.9.2",
-    "duo": "^0.8.4"
+    "duo": "^0.15.3"
   },
   "devDependencies": {
     "assert-dir-equal": "^1.0.1",


### PR DESCRIPTION
This updates the version of Duo used to the latest version.  The plugin api has changed a bit so plugins like [duo-myth](https://www.npmjs.com/package/duo-myth) weren't working correctly with the older version of Duo.
